### PR TITLE
Potential fix for code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/api/gist.js
+++ b/api/gist.js
@@ -4,6 +4,7 @@ import {
   renderError,
   parseBoolean,
 } from "../src/common/utils.js";
+import escapeHtml from "escape-html";
 import { isLocaleAvailable } from "../src/translations.js";
 import { renderGistCard } from "../src/cards/gist-card.js";
 import { fetchGist } from "../src/fetchers/gist-fetcher.js";
@@ -29,7 +30,7 @@ export default async (req, res) => {
   if (locale && !isLocaleAvailable(locale)) {
     return res.send(
       renderError("Something went wrong", "Language not found", {
-        title_color,
+        title_color: escapeHtml(title_color),
         text_color,
         bg_color,
         border_color,
@@ -78,7 +79,7 @@ export default async (req, res) => {
     ); // Use lower cache period for errors.
     return res.send(
       renderError(err.message, err.secondaryMessage, {
-        title_color,
+        title_color: escapeHtml(title_color),
         text_color,
         bg_color,
         border_color,

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "emoji-name-map": "^2.0.3",
     "github-username-regex": "^1.0.0",
     "upgrade": "^1.1.0",
-    "word-wrap": "^1.2.5"
+    "word-wrap": "^1.2.5",
+    "escape-html": "^1.0.3"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --write"


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/github-readme-stats/security/code-scanning/3](https://github.com/hixio-mh/github-readme-stats/security/code-scanning/3)

To fix the issue, we need to sanitize or escape the user-provided `title_color` parameter before passing it to the `renderError` function. This can be achieved using a library like `escape-html`, which ensures that special characters in the input are properly escaped to prevent XSS attacks. The fix involves importing the `escape-html` library and applying it to `title_color` before passing it to `renderError`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
