### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete URL substring sanitization

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -34,9 +34,9 @@ alert-autofix-3
       host === allowedDomain || host.endsWith(`.${allowedDomain}`)
   );
 
-  if (!isAllowedDomain)
-  if (!allowedDomains.includes(sanitizedDomain)) {
- master
+  // Ensure host matches or is a subdomain of an allowed domain
+
+  if (!isAllowedDomain) {
     throw new CustomError(
       `Invalid API domain: '${sanitizedDomain}'`,
       "INVALID_API_DOMAIN",


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/github-readme-stats/security/code-scanning/38](https://github.com/hixio-mh/github-readme-stats/security/code-scanning/38)

To fix the issue, the validation logic for `sanitizedDomain` should be updated to ensure that the domain is either an exact match or a valid subdomain of one of the allowed domains. This can be achieved by parsing the domain using `new URL()` and checking its `host` property against the allowlist. Specifically:

1. Parse the `sanitizedDomain` using `new URL()` to extract the `host`.
2. Check if the `host` matches any domain in the allowlist or ends with `.allowedDomain` (indicating a valid subdomain).
3. Replace the flawed `allowedDomains.includes(sanitizedDomain)` check with this improved validation logic.

The changes will be made in the `src/fetchers/wakatime-fetcher.js` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
