### PR TITLE
Potential fix for code scanning alert no. 34: Reflected cross-site scripting

### DIFF
--- a/api/gist.js
+++ b/api/gist.js
@@ -80,7 +80,7 @@ export default async (req, res) => {
     return res.send(
       renderError(err.message, err.secondaryMessage, {
         title_color: escapeHtml(title_color),
-        text_color,
+        text_color: escapeHtml(text_color),
         bg_color,
         border_color,
         theme,


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/github-readme-stats/security/code-scanning/34](https://github.com/hixio-mh/github-readme-stats/security/code-scanning/34)

To fix the issue, we need to sanitize the `text_color` parameter before passing it to the `renderError` function. This can be achieved by using the `escape-html` library, which is already imported in the file. The `escapeHtml` function will ensure that any potentially malicious characters in `text_color` are properly escaped, preventing XSS vulnerabilities.

The changes will involve:
1. Escaping `text_color` using `escapeHtml` before passing it to `renderError` in the error-handling block (line 83).
2. Ensuring consistency by escaping `text_color` in all other contexts where it is used in the response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
