### PR TITLE
Potential fix for code scanning alert no. 7: Reflected cross-site scripting

### DIFF
--- a/api/pin.js
+++ b/api/pin.js
@@ -1,4 +1,5 @@
 import { renderRepoCard } from "../src/cards/repo-card.js";
+import escapeHtml from "escape-html";
 import { blacklist } from "../src/common/blacklist.js";
 import {
   clampValue,
@@ -74,7 +75,7 @@ export default async (req, res) => {
       renderRepoCard(repoData, {
         hide_border: parseBoolean(hide_border),
         title_color,
-        icon_color,
+        icon_color: escapeHtml(icon_color),
         text_color,
         bg_color,
         theme,


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/github-readme-stats/security/code-scanning/7](https://github.com/hixio-mh/github-readme-stats/security/code-scanning/7)

To fix the issue, we need to sanitize or escape the `icon_color` parameter before passing it to `renderRepoCard`. This can be achieved using a library like `escape-html` or by implementing a custom sanitization function. The `escape-html` library is a well-known and reliable choice for escaping HTML content, ensuring that user-provided input cannot inject malicious scripts or markup.

The fix involves:
1. Importing the `escape-html` library.
2. Escaping the `icon_color` parameter before passing it to `renderRepoCard`.

This change ensures that any potentially malicious content in `icon_color` is neutralized, preventing XSS vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
