### PR TITLE
Potential fix for code scanning alert no. 31: Unsafe HTML constructed from library input

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -394,7 +394,7 @@ const renderError = (message, secondaryMessage = "", options = {}) => {
     }</text>
     <text data-testid="message" x="25" y="55" class="text small">
       <tspan x="25" dy="18">${encodeHTML(message)}</tspan>
-      <tspan x="25" dy="18" class="gray">${secondaryMessage}</tspan>
+      <tspan x="25" dy="18" class="gray">${encodeHTML(secondaryMessage)}</tspan>
     </text>
     </svg>
   `;


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/github-readme-stats/security/code-scanning/31](https://github.com/hixio-mh/github-readme-stats/security/code-scanning/31)

To fix the issue, we need to ensure that `secondaryMessage` is properly sanitized or escaped before being interpolated into the SVG. The best approach is to use an HTML-escaping utility function to encode any potentially unsafe characters in `secondaryMessage`. This will prevent malicious input from being interpreted as HTML or JavaScript. 

We will:
1. Use an existing `encodeHTML` function (if available) or implement a new one to escape special characters in `secondaryMessage`.
2. Replace the direct interpolation of `secondaryMessage` with its escaped version.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
